### PR TITLE
Add Chrome extension manifest and placeholder pages

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,11 @@
+{
+  "manifest_version": 3,
+  "name": "PDF Layout Buddy",
+  "version": "1.0.0",
+  "description": "Анализ и структура PDF-документов в Chrome",
+  "action": {
+    "default_title": "PDF Layout Buddy",
+    "default_popup": "popup.html"
+  },
+  "options_page": "options.html"
+}

--- a/options.html
+++ b/options.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PDF Layout Buddy Options</title>
+  </head>
+  <body>
+    <h1>PDF Layout Buddy Options</h1>
+    <p>Настройки расширения будут доступны позже.</p>
+  </body>
+</html>

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PDF Layout Buddy</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Add Manifest V3 config for PDF Layout Buddy Chrome extension
- Provide placeholder popup and options pages referenced by the manifest

## Testing
- `npm run lint` *(fails: 3 errors, 7 warnings)*
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4ae1d17888329b3e3fe0d1d5c1743