### PR TITLE
Use Link for home navigation in 404 page

### DIFF
--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,4 +1,4 @@
-import { useLocation } from "react-router-dom";
+import { useLocation, Link } from "react-router-dom";
 import { useEffect } from "react";
 
 const NotFound = () => {
@@ -16,9 +16,9 @@ const NotFound = () => {
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">404</h1>
         <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 hover:text-blue-700 underline">
+        <Link to="/" className="text-blue-500 hover:text-blue-700 underline">
           Return to Home
-        </a>
+        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- use React Router's `Link` in the NotFound page for navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 3 errors, 7 warnings)*
- `npx eslint src/pages/NotFound.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b4c2b805e88329b0a70bef569495ed