### PR TITLE
feat: render and analyze PDFs with pdfjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react-resizable-panels": "^2.1.3",
     "react-router-dom": "^6.26.2",
     "recharts": "^2.12.7",
+    "pdfjs-dist": "^4.0.379",
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,5 +7,11 @@
     "default_title": "PDF Layout Buddy",
     "default_popup": "popup.html"
   },
-  "options_page": "options.html"
+  "options_page": "options.html",
+  "web_accessible_resources": [
+    {
+      "resources": ["assets/*"],
+      "matches": ["<all_urls>"]
+    }
+  ]
 }

--- a/src/components/PDFAnalysisPanel.tsx
+++ b/src/components/PDFAnalysisPanel.tsx
@@ -1,10 +1,8 @@
 import { useState, useRef, useEffect } from 'react';
-import { MessageCircle, FileText, Send, Bot, User, Loader2 } from 'lucide-react';
+import { MessageCircle, Send, Bot, User } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Card } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 interface Message {
   id: string;
@@ -16,28 +14,17 @@ interface Message {
 interface PDFAnalysisPanelProps {
   fileName: string;
   isAnalyzing: boolean;
+  wordCount: number;
+  pages: number;
+  readingTime: number;
 }
 
-export const PDFAnalysisPanel = ({ fileName, isAnalyzing }: PDFAnalysisPanelProps) => {
+export const PDFAnalysisPanel = ({ fileName, isAnalyzing, wordCount, pages, readingTime }: PDFAnalysisPanelProps) => {
   const [messages, setMessages] = useState<Message[]>([]);
   const [inputMessage, setInputMessage] = useState('');
   const [isTyping, setIsTyping] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Mock summary data
-  const summary = {
-    title: "Анализ документа",
-    content: `Подробное резюме статьи "${fileName}". Документ содержит важную информацию о методах анализа данных и современных подходах к обработке информации. Ключевые темы включают машинное обучение, статистический анализ и практические применения.`,
-    keyPoints: [
-      "Введение в методы анализа данных",
-      "Статистические подходы и их применение", 
-      "Машинное обучение в современных исследованиях",
-      "Практические рекомендации и выводы"
-    ],
-    wordCount: 2847,
-    pages: 12,
-    readingTime: "11 минут"
-  };
 
   const handleSendMessage = async () => {
     if (!inputMessage.trim()) return;
@@ -97,6 +84,11 @@ export const PDFAnalysisPanel = ({ fileName, isAnalyzing }: PDFAnalysisPanelProp
         <p className="text-sm text-gray-600 mt-1">
           {fileName}
         </p>
+        <div className="text-xs text-gray-500 mt-2 flex space-x-4">
+          <span>Страниц: {pages}</span>
+          <span>Слов: {wordCount}</span>
+          <span>Время чтения: {readingTime} мин</span>
+        </div>
       </div>
 
       <div className="flex-1 flex flex-col">

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -8,6 +8,12 @@ const Index = () => {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [isAnalyzing, setIsAnalyzing] = useState(false);
   const [showAnalysis, setShowAnalysis] = useState(false);
+  const [pdfInfo, setPdfInfo] = useState<{ text: string; numPages: number; wordCount: number; readingTime: number }>({
+    text: '',
+    numPages: 0,
+    wordCount: 0,
+    readingTime: 0,
+  });
 
   const handleFileSelect = (file: File) => {
     setSelectedFile(file);
@@ -29,14 +35,17 @@ const Index = () => {
       <div className="h-screen flex">
         {/* PDF Viewer */}
         <div className="flex-1 border-r border-gray-200">
-          <PDFViewer file={selectedFile} onAnalyze={handleAnalyze} />
+          <PDFViewer file={selectedFile} onAnalyze={handleAnalyze} onLoad={setPdfInfo} />
         </div>
         
         {/* Analysis Panel */}
         <div className="w-96 bg-white">
-          <PDFAnalysisPanel 
-            fileName={selectedFile.name} 
+          <PDFAnalysisPanel
+            fileName={selectedFile.name}
             isAnalyzing={isAnalyzing}
+            wordCount={pdfInfo.wordCount}
+            pages={pdfInfo.numPages}
+            readingTime={pdfInfo.readingTime}
           />
         </div>
       </div>
@@ -46,7 +55,7 @@ const Index = () => {
   if (selectedFile) {
     return (
       <div className="h-screen">
-        <PDFViewer file={selectedFile} onAnalyze={handleAnalyze} />
+        <PDFViewer file={selectedFile} onAnalyze={handleAnalyze} onLoad={setPdfInfo} />
       </div>
     );
   }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -100,5 +101,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- integrate pdf.js to render selected PDFs and extract text, page count, word count and reading time
- surface PDF statistics in the analysis panel and expose worker to the extension
- fix eslint issues in shared UI utilities

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Rollup failed to resolve import "pdfjs-dist")*

------
https://chatgpt.com/codex/tasks/task_e_68b534bad3688329ab6c2e8ecc4204de