### PR TITLE
chore: remove unused X icon import

### DIFF
--- a/src/components/PDFUploader.tsx
+++ b/src/components/PDFUploader.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import { Upload, FileText, X } from 'lucide-react';
+import { Upload, FileText } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { useToast } from '@/hooks/use-toast';


### PR DESCRIPTION
## Summary
- remove unused `X` icon import from `PDFUploader`

## Testing
- `npm run lint`
- `npm run build` *(fails: Rollup failed to resolve import "pdfjs-dist"; could not install due to 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b53bc0e68883299fe90b02b84432ff