### PR TITLE
feat: add PDF viewer action callbacks

### DIFF
--- a/src/components/PDFViewer.tsx
+++ b/src/components/PDFViewer.tsx
@@ -8,7 +8,9 @@ import workerSrc from 'pdfjs-dist/build/pdf.worker.min.mjs?url';
 
 interface PDFViewerProps {
   file: File;
-  onAnalyze: () => void;
+  onTranslate: () => void;
+  onAsk: () => void;
+  onSummarize: () => void;
   onLoad?: (info: {
     text: string;
     numPages: number;
@@ -17,7 +19,7 @@ interface PDFViewerProps {
   }) => void;
 }
 
-export const PDFViewer = ({ file, onAnalyze, onLoad }: PDFViewerProps) => {
+export const PDFViewer = ({ file, onTranslate, onAsk, onSummarize, onLoad }: PDFViewerProps) => {
   const [zoom, setZoom] = useState(100);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [page, setPage] = useState<PDFPageProxy | null>(null);
@@ -125,7 +127,7 @@ export const PDFViewer = ({ file, onAnalyze, onLoad }: PDFViewerProps) => {
 
           <div className="flex items-center space-x-2">
             <Button
-              onClick={onAnalyze}
+              onClick={onTranslate}
               variant="pdf"
               size="sm"
             >
@@ -133,7 +135,7 @@ export const PDFViewer = ({ file, onAnalyze, onLoad }: PDFViewerProps) => {
             </Button>
 
             <Button
-              onClick={onAnalyze}
+              onClick={onAsk}
               variant="pdf"
               size="sm"
             >
@@ -141,7 +143,7 @@ export const PDFViewer = ({ file, onAnalyze, onLoad }: PDFViewerProps) => {
             </Button>
 
             <Button
-              onClick={onAnalyze}
+              onClick={onSummarize}
               variant="pdf"
               size="sm"
             >

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -20,22 +20,32 @@ const Index = () => {
     setShowAnalysis(false);
   };
 
-  const handleAnalyze = () => {
+  const startAnalysis = () => {
     setIsAnalyzing(true);
     setShowAnalysis(true);
-    
+
     // Simulate analysis process
     setTimeout(() => {
       setIsAnalyzing(false);
     }, 3000);
   };
 
+  const handleTranslate = () => startAnalysis();
+  const handleAsk = () => startAnalysis();
+  const handleSummarize = () => startAnalysis();
+
   if (selectedFile && showAnalysis) {
     return (
       <div className="h-screen flex">
         {/* PDF Viewer */}
         <div className="flex-1 border-r border-gray-200">
-          <PDFViewer file={selectedFile} onAnalyze={handleAnalyze} onLoad={setPdfInfo} />
+          <PDFViewer
+            file={selectedFile}
+            onTranslate={handleTranslate}
+            onAsk={handleAsk}
+            onSummarize={handleSummarize}
+            onLoad={setPdfInfo}
+          />
         </div>
         
         {/* Analysis Panel */}
@@ -55,7 +65,13 @@ const Index = () => {
   if (selectedFile) {
     return (
       <div className="h-screen">
-        <PDFViewer file={selectedFile} onAnalyze={handleAnalyze} onLoad={setPdfInfo} />
+        <PDFViewer
+          file={selectedFile}
+          onTranslate={handleTranslate}
+          onAsk={handleAsk}
+          onSummarize={handleSummarize}
+          onLoad={setPdfInfo}
+        />
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- split PDFViewer's single onAnalyze prop into onTranslate, onAsk, and onSummarize
- wire new callbacks to translate/ask/summarize buttons
- update Index page to provide corresponding handlers

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b53be1dddc832995a1d0df0d06c195