### PR TITLE
Handle absent chrome runtime in PDFViewer

### DIFF
--- a/src/components/PDFViewer.tsx
+++ b/src/components/PDFViewer.tsx
@@ -24,7 +24,14 @@ export const PDFViewer = ({ file, onAnalyze, onLoad }: PDFViewerProps) => {
 
   useEffect(() => {
     const loadPdf = async () => {
-      GlobalWorkerOptions.workerSrc = chrome.runtime.getURL(workerSrc);
+      if (typeof chrome !== 'undefined' && chrome.runtime) {
+        GlobalWorkerOptions.workerSrc = chrome.runtime.getURL(workerSrc);
+      } else {
+        GlobalWorkerOptions.workerSrc = workerSrc;
+        console.warn(
+          'chrome.runtime is not available; using workerSrc directly'
+        );
+      }
       const arrayBuffer = await file.arrayBuffer();
       const pdf = await getDocument({ data: arrayBuffer }).promise;
       const firstPage = await pdf.getPage(1);


### PR DESCRIPTION
## Summary
- ensure PDF viewer sets workerSrc without chrome runtime
- warn when chrome.runtime is unavailable

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b53bd465f883299e5ad60168bd4992