### PR TITLE
Replace deprecated onKeyPress with onKeyDown in PDFAnalysisPanel

### DIFF
--- a/src/components/PDFAnalysisPanel.tsx
+++ b/src/components/PDFAnalysisPanel.tsx
@@ -67,7 +67,7 @@ export const PDFAnalysisPanel = ({ fileName, isAnalyzing, wordCount, pages, read
     };
   }, []);
 
-  const handleKeyPress = (e: React.KeyboardEvent) => {
+  const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       handleSendMessage();
@@ -162,7 +162,7 @@ export const PDFAnalysisPanel = ({ fileName, isAnalyzing, wordCount, pages, read
             <Input
               value={inputMessage}
               onChange={(e) => setInputMessage(e.target.value)}
-              onKeyPress={handleKeyPress}
+              onKeyDown={handleKeyDown}
               placeholder="Задайте вопрос о документе..."
               className="flex-1"
               disabled={isAnalyzing}


### PR DESCRIPTION
## Summary
- use `onKeyDown` instead of deprecated `onKeyPress` for message input
- ensure Enter key submission is handled via `handleKeyDown`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b53bbcfb9c83299fe017185fce48e9